### PR TITLE
 Rest parameter syntax for functions

### DIFF
--- a/0x00-ES6_basic/4-rest-parameter.js
+++ b/0x00-ES6_basic/4-rest-parameter.js
@@ -1,0 +1,3 @@
+export default function returnHowManyArguments(...theArgs) {
+  return theArgs.length;
+}

--- a/0x00-ES6_basic/test/4-main.js
+++ b/0x00-ES6_basic/test/4-main.js
@@ -1,0 +1,4 @@
+import returnHowManyArguments from './4-rest-parameter.js';
+
+console.log(returnHowManyArguments("one"));
+console.log(returnHowManyArguments("one", "two", 3, "4th"));


### PR DESCRIPTION
Modify the  function to return the number of arguments passed to it using the rest parameter syntax