### PR TITLE
Primitive - Holberton Class

### DIFF
--- a/0x02-ES6_classes/8-hbtn_class.js
+++ b/0x02-ES6_classes/8-hbtn_class.js
@@ -1,0 +1,19 @@
+export default class HolbertonClass {
+  constructor(size, location) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Size must be a number');
+    } else if (typeof location !== 'string') {
+      throw new TypeError('Location must be a string');
+    }
+
+    this._size = size;
+    this._location = location;
+  }
+
+  [Symbol.toPrimitive](hint) {
+    if (hint === 'number') {
+      return this._size;
+    }
+    return this._location;
+  }
+}

--- a/0x02-ES6_classes/__tests__/8-main.js
+++ b/0x02-ES6_classes/__tests__/8-main.js
@@ -1,0 +1,6 @@
+import HolbertonClass from "./8-hbtn_class.js";
+
+const hc = new HolbertonClass(12, "Mezzanine")
+console.log(Number(hc));
+console.log(String(hc));
+


### PR DESCRIPTION
Implement a class named HolbertonClass:

Constructor attributes:
size (Number)
location (String)
Each attribute  stored in an “underscore” attribute version (ex: name is stored in _name)
When the class is cast into a Number, it should return the size.
When the class is cast into a String, it should return the location.