### PR TITLE
Rewrite the return statement

### DIFF
--- a/0x00-ES6_basic/6-string-interpolation.js
+++ b/0x00-ES6_basic/6-string-interpolation.js
@@ -1,0 +1,12 @@
+export default function getSanFranciscoDescription() {
+  const year = 2017;
+  const budget = {
+    income: '$119,868',
+    gdp: '$154.2 billion',
+    capita: '$178,479',
+  };
+
+  return `As of ${year}, it was the seventh-highest income county in the United States, 
+          with a per capita personal income of ${budget.income}. As of 2015, San Francisco 
+          proper had a GDP of ${budget.gdp}, and a GDP per capita of ${budget.capita}.`;
+}

--- a/0x00-ES6_basic/test/6-main.js
+++ b/0x00-ES6_basic/test/6-main.js
@@ -1,0 +1,3 @@
+import getSanFranciscoDescription from './6-string-interpolation.js';
+
+console.log(getSanFranciscoDescription());


### PR DESCRIPTION
Rewrite the return statement to use a template literal, so you can the substitute the defined variables  .