### PR TITLE
Object property value shorthand syntax

### DIFF
--- a/0x00-ES6_basic/7-getBudgetObject.js
+++ b/0x00-ES6_basic/7-getBudgetObject.js
@@ -1,0 +1,10 @@
+export default function getBudgetObject(income, gdp, capita) {
+  const budget = {
+    income,
+    gdp,
+    capita,
+  };
+
+  return budget;
+}
+

--- a/0x00-ES6_basic/test/7-main.js
+++ b/0x00-ES6_basic/test/7-main.js
@@ -1,0 +1,3 @@
+import getBudgetObject from './7-getBudgetObject.js';
+
+console.log(getBudgetObject(400, 700, 900));


### PR DESCRIPTION
Modify the  function’s budget object to simply use the keyname instead.