### PR TITLE
install Sinon with npm

### DIFF
--- a/0x06-unittests_in_js/3-payment.js
+++ b/0x06-unittests_in_js/3-payment.js
@@ -1,0 +1,11 @@
+/**
+ * Payment script
+ */
+const Utils = require('./utils');
+
+const sendPaymentRequestToApi = (totalAmount, totalShipping) => {
+  const totalCost = Utils.calculateNumber('SUM', totalAmount, totalShipping);
+  console.log(`The total is: ${totalCost}`);
+};
+
+module.exports = sendPaymentRequestToApi;

--- a/0x06-unittests_in_js/3-payment.test.js
+++ b/0x06-unittests_in_js/3-payment.test.js
@@ -1,0 +1,30 @@
+/**
+ * Test  payment
+ */
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const Utils = require('./utils');
+const sendPaymentRequestToApi = require('./3-payment');
+
+describe('sendPaymentRequestToAp', function() {
+  beforeEach(function() {
+    sinon.spy(Utils, 'calculateNumber');
+  });
+  afterEach(function() {
+    sinon.restore();
+  });
+  it("validate the usage of the `Utils.calculateNumber` function", function() {
+    sendPaymentRequestToApi(100, 20);
+    // Check it is called
+    expect(Utils.calculateNumber.called).to.be.true;
+    // Check it is called once
+    expect(Utils.calculateNumber.calledOnce).to.be.true;
+    // Check call count
+    expect(Utils.calculateNumber.callCount).to.be.equal(1);
+    // Check it first argument
+    expect(Utils.calculateNumber.firstCall.args[0]).to.equal("SUM");
+    // Check params
+    expect(Utils.calculateNumber.calledWith('SUM', 100, 20)).to.be.true;
+  });
+});


### PR DESCRIPTION

**Summary:**

This pull request (PR) aims to achieve the following objectives:

1. **Install Sinon with npm:**
   Sinon, a testing library, is installed using npm to facilitate the creation of spies for testing purposes.

2. **Create a new file named utils.js:**
   A new file named `utils.js` is created to contain utility functions for the project.

3. **Create a new module named Utils:**
   Within `utils.js`, a module named `Utils` is defined to encapsulate utility functions.

4. **Create a property named calculateNumber:**
   Within the `Utils` module, a property named `calculateNumber` is defined to perform arithmetic operations.

5. **Export the Utils module:**
   The `Utils` module, containing the `calculateNumber` property, is exported to make it accessible to other modules.

6. **Create a new file named 3-payment.js:**
   A new file named `3-payment.js` is created to implement the `sendPaymentRequestToApi` function.

7. **Implement sendPaymentRequestToApi function:**
   Within `3-payment.js`, the `sendPaymentRequestToApi` function is implemented. This function takes two arguments, `totalAmount` and `totalShipping`, and calls `Utils.calculateNumber` with type `SUM`. It then displays the calculated total in the console.

8. Create a new file named 3-payment.test.js:
   A new file named `3-payment.test.js` is created to test the `sendPaymentRequestToApi` function.

9. Test sendPaymentRequestToApi function:
   Within `3-payment.test.js`, a suite named `sendPaymentRequestToApi` is added. Using `sinon.spy`, it ensures that the mathematical calculation performed by `sendPaymentRequestToApi(100, 20)` matches the calculation performed by `Utils.calculateNumber('SUM', 100, 20)`, thus validating the correct usage of the `Utils` function.

By achieving these objectives, this PR enhances the project's testing capabilities and ensures the correctness of the `sendPaymentRequestToApi` function, contributing to the overall reliability and maintainability of the codebase.